### PR TITLE
fixed draw position usages

### DIFF
--- a/static/game/creature.js
+++ b/static/game/creature.js
@@ -231,7 +231,7 @@ export class Creature extends Entity {
       this.pos.add(dir.mult(this.width / 2)),
       dir.norm2().mult(this.bulletSpeed),
       new Vector(0, 0),
-      (this.type === "Hero"),
+      this.type === "Hero",
       this.bulletColor,
       this.bulletLifetime,
       this.bulletDamage
@@ -250,10 +250,7 @@ export class Creature extends Entity {
    * @param {Vector} dir the direction to shoot in
    * @param {Vector} [additionalVelocity]
    */
-  shoot(
-    dir,
-    additionalVelocity = new Vector(0, 0)
-  ) {
+  shoot(dir, additionalVelocity = new Vector(0, 0)) {
     dir = dir.norm2();
     // Conditional is so fire count doesn't roll over before shooting
     if (this.fireCount < this.fireDelay) {
@@ -291,7 +288,7 @@ export class Creature extends Entity {
    * @param {boolean} [isGood] true if the bomb was planted by the player,
    * false otherwise
    */
-  placeBomb(pos = this.drawPos, isGood = false) {
+  placeBomb(pos = this.pos, isGood = false) {
     if (this.currentBombs > 0) {
       const b = this.getBomb(pos);
       addToWorld(b);

--- a/static/game/hero.js
+++ b/static/game/hero.js
@@ -112,7 +112,7 @@ export class Hero extends Creature {
     }
 
     if (buttons.primary.status.isPressed) {
-      this.placeBomb(this.drawPos);
+      this.placeBomb(this.pos);
     }
     if (buttons.secondary.status.isPressed) {
       console.log("Secondary pressed");

--- a/static/game/powerup.js
+++ b/static/game/powerup.js
@@ -68,6 +68,7 @@ export class PowerUp extends Entity {
     // display the name on the screen if the hero picked it up
     // this needs to be last in case something changes before we get here
     if (creature.type === "Hero") {
+      // this draw position usage is fine
       const textPos = this.drawPos.add(new Vector(0, -100));
       const td = new TextDisplay(
         this.powerUpClass + " " + this.magnitude,

--- a/static/game/powerups/groupbomb.js
+++ b/static/game/powerups/groupbomb.js
@@ -45,7 +45,7 @@ export class GroupBomb extends PowerUp {
           let r = bomb.speed;
           if (r < 2) r = 2;
           const newVel = new Vector(Math.cos(theta) * r, Math.sin(theta) * r);
-          const child = creature.getBomb(bomb.drawPos);
+          const child = creature.getBomb(bomb.pos);
           child.vel = newVel;
           child.speed = r;
           child.wallReflectSpeed = r;

--- a/static/game/statuseffects/burning.js
+++ b/static/game/statuseffects/burning.js
@@ -39,9 +39,10 @@ export class Burning extends StatusEffect {
       } else {
         color = "hsl(" + Math.floor(Math.random() * 55 - 5) + ", 100%, 50%)";
       }
-      const xOffset = Math.random() * creature.width - (creature.width / 2);
-      const yOffset = Math.random() * creature.height - (creature.height / 2);
+      const xOffset = Math.random() * creature.width - creature.width / 2;
+      const yOffset = Math.random() * creature.height - creature.height / 2;
       const p = new Particle(
+        // this draw position is fine
         new Vector(creature.drawPos.x + xOffset, creature.drawPos.y + yOffset),
         color,
         EffectEnum.square,


### PR DESCRIPTION
You're right that it looks more correct for particles to spawn at drawPos. I just fixed some of the places where bombs spawn at the draw position of the hero or parent bomb. This looks identical and gameplay and has less chance of causing problems.