### PR TITLE
Powerup tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "proc-cave-game",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proc-cave-game",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "a game where you shoot procedurally generated enemies in procedurally generated caves",
   "main": "main.js",
   "directories": {

--- a/static/game/chase.js
+++ b/static/game/chase.js
@@ -24,9 +24,9 @@ export class Chase extends Enemy {
     super(pos, vel, acc, matryoshka);
     this.basePoints = 40;
     this.drag = 0.015;
-    this.maxHealth = 2;
-    this.gainHealth(2);
-    this.collideMap.set("PlayerBullet", e => {
+    this.maxHealth = 24 * (matryoshka + 1);
+    this.gainHealth(this.maxHealth);
+    this.collideMap.set("PlayerBullet", () => {
       this.followTimer = this.followTimerMax;
     });
   }

--- a/static/game/creature.js
+++ b/static/game/creature.js
@@ -108,14 +108,14 @@ export class Creature extends Entity {
   bombSpeed = 0;
 
   /** @type {number} the amount of damage this can take before dying */
-  maxHealth = 10;
+  maxHealth = 20;
 
   /**
    * @type {number} this creature's current health. Don't directly get or set
    * this! Instead use `takeDamage()` or `gainHealth()`
    * @private
    */
-  currentHealth = 10;
+  currentHealth = 20;
 
   /** @type {number} maximum number of bombs this creature can hold */
   maxBombs = 3;
@@ -127,7 +127,7 @@ export class Creature extends Entity {
   currentBombs = 3;
 
   /** @type {number} the amount of damage each bullet deals */
-  bulletDamage = 1;
+  bulletDamage = 8;
 
   /** @type {number} size of bullets spawned by this */
   bulletSize = 24;
@@ -203,7 +203,7 @@ export class Creature extends Entity {
     // bombs deal basic damage
     this.bombOnBlastCreature.push({
       name: "Basic Damage",
-      data: 1,
+      data: 12,
       func: (bomb, num, creature) => {
         creature.takeDamage(num);
       }

--- a/static/game/creature.js
+++ b/static/game/creature.js
@@ -320,13 +320,8 @@ export class Creature extends Entity {
     b.speed = this.bombSpeed;
     b.timeToExplode = this.bombTimeToExplode;
     b.owner = this;
-    if (!this.vel.isZeroVec()) {
+    if (this.vel.mag() > 1) {
       b.vel = this.vel.norm2().mult(b.speed);
-    } else {
-      // pick a random direction
-      const theta = Math.random() * Math.PI * 2;
-      const r = b.speed;
-      b.vel = new Vector(Math.cos(theta) * r, Math.sin(theta) * r);
     }
     b.reflectsOffWalls = true;
     b.wallReflectSpeed = this.bombSpeed;

--- a/static/game/creature.js
+++ b/static/game/creature.js
@@ -132,6 +132,18 @@ export class Creature extends Entity {
   /** @type {number} size of bullets spawned by this */
   bulletSize = 24;
 
+  /** @type {number} added to damage each left-facing bullet deals */
+  leftBulletDamage = 0;
+
+  /** @type {number} added to size of each left-facing bullet */
+  leftBulletSize = 0;
+
+  /** @type {number} added to damage each right-facing bullet deals */
+  rightBulletDamage = 0;
+
+  /** @type {number} added to size of each right-facing bullet */
+  rightBulletSize = 0;
+
   /** @type {number} A multiplier for how fast the creature moves */
   movementMultiplier = 1;
 
@@ -227,6 +239,19 @@ export class Creature extends Entity {
    * @return {Bullet}
    */
   getBullet(dir) {
+    /** @type {number} */
+    let dmg = this.bulletDamage;
+    /** @type {number} */
+    let size = this.bulletSize;
+    if (dir.x < 0.01 && Math.abs(dir.x) >= Math.abs(dir.y)) {
+      // left-facing
+      dmg += this.leftBulletDamage;
+      size += this.leftBulletSize;
+    } else if (dir.x > 0.01 && Math.abs(dir.x) >= Math.abs(dir.y)) {
+      // right-facing
+      dmg += this.rightBulletDamage;
+      size += this.rightBulletSize;
+    }
     const b = new Bullet(
       this.pos.add(dir.mult(this.width / 2)),
       dir.norm2().mult(this.bulletSpeed),
@@ -234,13 +259,13 @@ export class Creature extends Entity {
       this.type === "Hero",
       this.bulletColor,
       this.bulletLifetime,
-      this.bulletDamage
+      dmg
     );
     b.reflectsOffWalls = this.bulletReflectsOffWalls;
     b.wallReflectSpeed = this.bulletWallReflectSpeed;
     b.onDestroy = this.bulletOnDestroy;
     b.onHitEnemy = this.bulletOnHitEnemy;
-    b.width = this.bulletSize;
+    b.width = size;
     b.knockback = this.bulletKnockback;
     return b;
   }

--- a/static/game/crosser.js
+++ b/static/game/crosser.js
@@ -21,8 +21,8 @@ export class Crosser extends Enemy {
     matryoshka = 0
   ) {
     super(pos, vel, acc, matryoshka);
-    this.currentHealth = 1;
-    this.currentHealth = this.maxHealth;
+    this.maxHealth = 25 * (matryoshka + 1);
+    this.gainHealth(this.maxHealth);
     this.basePoints = 60;
 
     // stuff for shooting

--- a/static/game/enemy.js
+++ b/static/game/enemy.js
@@ -35,7 +35,7 @@ const BOMB_CHANCE = 0.3;
  */
 
 export class Enemy extends Creature {
-  health = 2;
+  health = 20;
   basePoints = 50;
 
   /**

--- a/static/game/hero.js
+++ b/static/game/hero.js
@@ -36,6 +36,7 @@ export class Hero extends Creature {
     this.gainHealth(this.maxHealth);
     this.bulletSpeed = 8;
     this.bulletLifetime = 60;
+    this.bulletDamage = 8;
     this.bombFuseTime = 300;
     this.bombHue = 126;
     this.bulletColor = "white";
@@ -157,9 +158,6 @@ export class Hero extends Creature {
   takeDamage(amt) {
     if (this.invincibilityFrames <= 0) {
       super.takeDamage(amt);
-      // TODO check this
-      //if (this.currentHealth <= 0) this.destroy();
-      //else this.invincibilityFrames = this.invincibilityFramesMax;
       this.invincibilityFrames = this.invincibilityFramesMax;
     }
   }

--- a/static/game/pausescreen.js
+++ b/static/game/pausescreen.js
@@ -55,7 +55,7 @@ export class PauseScreen extends Menu {
         text: "Give up",
         func: () => {
           const hero = /** @type {Hero} */ (getImportantEntity("hero"));
-          hero.takeDamage(hero.maxHealth);
+          hero.takeDamage(Infinity);
           this.onBack();
         }
       },

--- a/static/game/powerups/amplify.js
+++ b/static/game/powerups/amplify.js
@@ -3,7 +3,7 @@ import { Vector } from "../../modules/vector.js";
 import { Creature } from "../creature.js";
 
 const MAX_BULLET_SIZE = 300;
-const BULLET_SIZE_FACTOR = 1;
+const BULLET_SIZE_FACTOR = 2;
 
 export class Amplify extends PowerUp {
   /**

--- a/static/game/powerups/cone.js
+++ b/static/game/powerups/cone.js
@@ -3,7 +3,7 @@ import { Vector } from "../../modules/vector.js";
 import { Creature } from "../creature.js";
 
 const MAX_SPLIT_BULLETS = 10;
-const BULLET_DAMAGE_FACTOR = 1.2;
+const FIRE_DELAY_ADDEND = 15;
 
 export class Cone extends PowerUp {
   /**
@@ -24,7 +24,7 @@ export class Cone extends PowerUp {
     if (!this.isAtMax(creature)) {
       super.apply(creature);
       creature.bulletsPerShot += this.magnitude;
-      creature.bulletDamage *= (1 / this.magnitude) * BULLET_DAMAGE_FACTOR;
+      creature.fireDelay += this.magnitude * FIRE_DELAY_ADDEND;
     } else {
       super.overflowAction(creature);
     }

--- a/static/game/powerups/damageup.js
+++ b/static/game/powerups/damageup.js
@@ -3,7 +3,7 @@ import { Vector } from "../../modules/vector.js";
 import { Creature } from "../creature.js";
 
 const MAX_DAMAGE = 1000;
-const DAMAGE_FACTOR = 1;
+const DAMAGE_FACTOR = 5;
 
 export class DamageUp extends PowerUp {
   /**

--- a/static/game/powerups/flamethrower.js
+++ b/static/game/powerups/flamethrower.js
@@ -5,6 +5,7 @@ import { Bullet } from "../bullet.js";
 import { Burning } from "../statuseffects/burning.js";
 
 const BURNING_LENGTH_FACTOR = 1;
+const BURNING_CHANCE_FACTOR = 0.05;
 
 export class FlameThrower extends PowerUp {
   /**
@@ -30,7 +31,9 @@ export class FlameThrower extends PowerUp {
        * @param {Creature} other the creature we hit
        */
       const f = (b, duration = 1, other) => {
-        new Burning(duration * BURNING_LENGTH_FACTOR * 60).apply(other);
+        if (this.magnitude * BURNING_CHANCE_FACTOR < Math.random()) {
+          new Burning(duration * BURNING_LENGTH_FACTOR * 60).apply(other);
+        }
       };
 
       creature.bulletOnHitEnemy.push({

--- a/static/game/powerups/left.js
+++ b/static/game/powerups/left.js
@@ -3,7 +3,7 @@ import { Vector } from "../../modules/vector.js";
 import { Creature } from "../creature.js";
 
 const MAX_LEFT_DAMAGE = 1000;
-const DAMAGE_FACTOR = 1;
+const DAMAGE_FACTOR = 5;
 const SIZE_FACTOR = 2;
 
 export class Left extends PowerUp {

--- a/static/game/powerups/left.js
+++ b/static/game/powerups/left.js
@@ -2,17 +2,18 @@ import { PowerUp } from "../powerup.js";
 import { Vector } from "../../modules/vector.js";
 import { Creature } from "../creature.js";
 
-const MIN_SIZE = 20;
-const SIZE_FACTOR = 5;
+const MAX_LEFT_DAMAGE = 1000;
+const DAMAGE_FACTOR = 1;
+const SIZE_FACTOR = 2;
 
-export class Littlify extends PowerUp {
+export class Left extends PowerUp {
   /**
-   * Makes you smaller
+   * Makes your left-facing shots more powerful
    * @param {number} magnitude how much smaller this makes you, 1-5
    * @param {Vector} [pos]
    */
   constructor(magnitude = 1, pos) {
-    super(magnitude, pos, "Littlify", "Makes you smaller");
+    super(magnitude, pos, "Left", "Deal more damage when shooting left");
   }
 
   /**
@@ -23,8 +24,8 @@ export class Littlify extends PowerUp {
   apply(creature) {
     if (!this.isAtMax(creature)) {
       super.apply(creature);
-      creature.width -= this.magnitude * SIZE_FACTOR;
-      creature.height -= this.magnitude * SIZE_FACTOR;
+      creature.leftBulletDamage += this.magnitude * DAMAGE_FACTOR;
+      creature.leftBulletSize += this.magnitude * SIZE_FACTOR;
     } else {
       this.overflowAction(creature);
     }
@@ -38,13 +39,13 @@ export class Littlify extends PowerUp {
    */
   isAtMax(creature) {
     // creature is just too big
-    if (creature.width <= MIN_SIZE || creature.height <= MIN_SIZE) {
+    if (creature.leftBulletDamage >= MAX_LEFT_DAMAGE) {
       return true;
     }
 
     // see if we need to trim magnitude
     const availMag = Math.floor(
-      Math.abs(MIN_SIZE - creature.width) / SIZE_FACTOR
+      Math.abs(MAX_LEFT_DAMAGE - creature.leftBulletDamage) / DAMAGE_FACTOR
     );
     if (availMag < 1) return true;
 

--- a/static/game/powerups/poweruptypes.js
+++ b/static/game/powerups/poweruptypes.js
@@ -9,13 +9,13 @@ import { Hot } from "./hot.js";
 import { Icy } from "./icy.js";
 import { Jalapeno } from "./jalapeno.js";
 import { Knapsack } from "./knapsack.js";
-import { Littlify } from "./littlify.js";
+import { Left } from "./left.js";
 import { MachineGun } from "./machinegun.js";
 import { Nitroglycerin } from "./nitroglycerin.js";
 import { Orb } from "./orb.js";
 import { Popsicle } from "./popsicle.js";
 import { QuickShot } from "./quickshot.js";
-import { RovingBombs } from "./rovingbombs.js";
+import { Right } from "./right.js";
 import { SlipperyBombs } from "./slipperybombs.js";
 import { Thermalite } from "./thermalite.js";
 import { UltraBomb } from "./ultrabomb.js";
@@ -38,13 +38,13 @@ export {
   Icy,
   Jalapeno,
   Knapsack,
-  Littlify,
+  Left,
   MachineGun,
   Nitroglycerin,
   Orb,
   Popsicle,
   QuickShot,
-  RovingBombs,
+  Right,
   SlipperyBombs,
   Thermalite,
   UltraBomb,
@@ -68,13 +68,13 @@ export const powerUpTypes = [
   Icy,
   Jalapeno,
   Knapsack,
-  Littlify,
+  Left,
   MachineGun,
   Nitroglycerin,
   Orb,
   Popsicle,
   QuickShot,
-  RovingBombs,
+  Right,
   SlipperyBombs,
   Thermalite,
   UltraBomb,

--- a/static/game/powerups/poweruptypes.js
+++ b/static/game/powerups/poweruptypes.js
@@ -16,7 +16,7 @@ import { Orb } from "./orb.js";
 import { Popsicle } from "./popsicle.js";
 import { QuickShot } from "./quickshot.js";
 import { RovingBombs } from "./rovingbombs.js";
-import { Sniper } from "./sniper.js";
+import { SlipperyBombs } from "./slipperybombs.js";
 import { Thermalite } from "./thermalite.js";
 import { UltraBomb } from "./ultrabomb.js";
 import { Vitality } from "./vitality.js";
@@ -45,7 +45,7 @@ export {
   Popsicle,
   QuickShot,
   RovingBombs,
-  Sniper,
+  SlipperyBombs,
   Thermalite,
   UltraBomb,
   Vitality,
@@ -75,7 +75,7 @@ export const powerUpTypes = [
   Popsicle,
   QuickShot,
   RovingBombs,
-  Sniper,
+  SlipperyBombs,
   Thermalite,
   UltraBomb,
   Vitality,

--- a/static/game/powerups/right.js
+++ b/static/game/powerups/right.js
@@ -3,7 +3,7 @@ import { Vector } from "../../modules/vector.js";
 import { Creature } from "../creature.js";
 
 const MAX_RIGHT_DAMAGE = 1000;
-const DAMAGE_FACTOR = 1;
+const DAMAGE_FACTOR = 5;
 const SIZE_FACTOR = 2;
 
 export class Right extends PowerUp {

--- a/static/game/powerups/right.js
+++ b/static/game/powerups/right.js
@@ -2,17 +2,18 @@ import { PowerUp } from "../powerup.js";
 import { Vector } from "../../modules/vector.js";
 import { Creature } from "../creature.js";
 
-const MAX_BOMB_SPEED = 20;
-const BOMB_SPEED_FACTOR = 1;
+const MAX_RIGHT_DAMAGE = 1000;
+const DAMAGE_FACTOR = 1;
+const SIZE_FACTOR = 2;
 
-export class RovingBombs extends PowerUp {
+export class Right extends PowerUp {
   /**
-   * Makes your bombs move after being placed
-   * @param {number} magnitude how fast the bombs will move you become, 1-5
+   * Makes your right-facing shots more powerful
+   * @param {number} magnitude how much smaller this makes you, 1-5
    * @param {Vector} [pos]
    */
   constructor(magnitude = 1, pos) {
-    super(magnitude, pos, "Roving Bombs", "Your bombs move");
+    super(magnitude, pos, "Right", "Deal more damage when shooting right");
   }
 
   /**
@@ -23,7 +24,8 @@ export class RovingBombs extends PowerUp {
   apply(creature) {
     if (!this.isAtMax(creature)) {
       super.apply(creature);
-      creature.bombSpeed += this.magnitude * BOMB_SPEED_FACTOR;
+      creature.rightBulletDamage += this.magnitude * DAMAGE_FACTOR;
+      creature.rightBulletSize += this.magnitude * SIZE_FACTOR;
     } else {
       this.overflowAction(creature);
     }
@@ -36,14 +38,14 @@ export class RovingBombs extends PowerUp {
    * @override
    */
   isAtMax(creature) {
-    // check if bombSpeed is already too high
-    if (creature.bombSpeed >= MAX_BOMB_SPEED) {
+    // creature is just too big
+    if (creature.rightBulletDamage >= MAX_RIGHT_DAMAGE) {
       return true;
     }
 
     // see if we need to trim magnitude
     const availMag = Math.floor(
-      Math.abs(MAX_BOMB_SPEED - creature.bombSpeed) / BOMB_SPEED_FACTOR
+      Math.abs(MAX_RIGHT_DAMAGE - creature.rightBulletDamage) / DAMAGE_FACTOR
     );
     if (availMag < 1) return true;
 

--- a/static/game/powerups/slipperybombs.js
+++ b/static/game/powerups/slipperybombs.js
@@ -2,17 +2,17 @@ import { PowerUp } from "../powerup.js";
 import { Vector } from "../../modules/vector.js";
 import { Creature } from "../creature.js";
 
-const MAX_BULLET_LIFETIME = 500;
-const RANGE_FACTOR = 5;
+const MAX_BOMB_SPEED = 20;
+const BOMB_SPEED_FACTOR = 1;
 
-export class Sniper extends PowerUp {
+export class SlipperyBombs extends PowerUp {
   /**
-   * Increases your range (by increasing bullet lifetime)
-   * @param {number} magnitude how much this increases your range by, 1-5
+   * Makes your bombs move after being placed
+   * @param {number} magnitude how fast your bombs will move, 1-5
    * @param {Vector} [pos]
    */
   constructor(magnitude = 1, pos) {
-    super(magnitude, pos, "Sniper", "You can shoot farther");
+    super(magnitude, pos, "Slippery Bombs", "Your bombs move");
   }
 
   /**
@@ -23,7 +23,7 @@ export class Sniper extends PowerUp {
   apply(creature) {
     if (!this.isAtMax(creature)) {
       super.apply(creature);
-      creature.bulletLifetime += this.magnitude * RANGE_FACTOR;
+      creature.bombSpeed += this.magnitude * BOMB_SPEED_FACTOR;
     } else {
       this.overflowAction(creature);
     }
@@ -36,14 +36,14 @@ export class Sniper extends PowerUp {
    * @override
    */
   isAtMax(creature) {
-    // creature is just too big
-    if (creature.bulletLifetime >= MAX_BULLET_LIFETIME) {
+    // check if bombSpeed is already too high
+    if (creature.bombSpeed >= MAX_BOMB_SPEED) {
       return true;
     }
 
     // see if we need to trim magnitude
     const availMag = Math.floor(
-      Math.abs(MAX_BULLET_LIFETIME - creature.bulletLifetime) / RANGE_FACTOR
+      Math.abs(MAX_BOMB_SPEED - creature.bombSpeed) / BOMB_SPEED_FACTOR
     );
     if (availMag < 1) return true;
 

--- a/static/game/powerups/xplode.js
+++ b/static/game/powerups/xplode.js
@@ -5,7 +5,7 @@ import { Bullet } from "../bullet.js";
 import { addToWorld } from "../../modules/gamemanager.js";
 
 const MAX_EXPLODES = 10;
-const FIRE_DELAY_ADDEND = 10;
+const BULLET_DAMAGE_FACTOR = 1.2;
 
 export class Xplode extends PowerUp {
   /**
@@ -31,6 +31,8 @@ export class Xplode extends PowerUp {
   apply(creature) {
     if (!this.isAtMax(creature)) {
       super.apply(creature);
+
+      creature.bulletDamage *= (1 / this.magnitude) * BULLET_DAMAGE_FACTOR;
 
       // if the creature already has an Xplode powerup, just increase its data
       // value so it spawns more bullets to implement stacking
@@ -70,7 +72,6 @@ export class Xplode extends PowerUp {
         }
       };
 
-      creature.fireDelay += FIRE_DELAY_ADDEND * this.magnitude;
       creature.bulletOnDestroy.push({
         name: this.powerUpClass,
         data: this.magnitude,

--- a/static/game/powerups/yeet.js
+++ b/static/game/powerups/yeet.js
@@ -2,17 +2,17 @@ import { PowerUp } from "../powerup.js";
 import { Vector } from "../../modules/vector.js";
 import { Creature } from "../creature.js";
 
-const MAX_BULLET_KNOCKBACK = 40;
-const BULLET_KNOCKBACK_FACTOR = 4;
+const MAX_BULLET_LIFETIME = 500;
+const RANGE_FACTOR = 5;
 
 export class Yeet extends PowerUp {
   /**
-   * Increases bullet knockback
-   * @param {number} magnitude how much to increase bullet knockback by, 1-5
+   * Increases your range (by increasing bullet lifetime)
+   * @param {number} magnitude how much to increase bullet lifetime by, 1-5
    * @param {Vector} [pos]
    */
   constructor(magnitude = 1, pos) {
-    super(magnitude, pos, "Yeet", "Your bullets deal more knock-back");
+    super(magnitude, pos, "Yeet", "You can shoot farther");
   }
 
   /**
@@ -23,7 +23,7 @@ export class Yeet extends PowerUp {
   apply(creature) {
     if (!this.isAtMax(creature)) {
       super.apply(creature);
-      creature.bulletKnockback += this.magnitude * BULLET_KNOCKBACK_FACTOR;
+      creature.bulletLifetime += this.magnitude * RANGE_FACTOR;
     } else {
       this.overflowAction(creature);
     }
@@ -37,14 +37,13 @@ export class Yeet extends PowerUp {
    */
   isAtMax(creature) {
     // check if bullet knockback is already too high
-    if (creature.bulletKnockback >= MAX_BULLET_KNOCKBACK) {
+    if (creature.bulletKnockback >= MAX_BULLET_LIFETIME) {
       return true;
     }
 
     // see if we need to trim magnitude
     const availMag = Math.floor(
-      (MAX_BULLET_KNOCKBACK - creature.bulletKnockback) /
-        BULLET_KNOCKBACK_FACTOR
+      Math.abs(MAX_BULLET_LIFETIME - creature.bulletLifetime) / RANGE_FACTOR
     );
     if (availMag < 1) return true;
 

--- a/static/game/scatter.js
+++ b/static/game/scatter.js
@@ -18,11 +18,9 @@ export class Scatter extends Enemy {
     matryoshka = 0
   ) {
     super(pos, vel, acc, matryoshka);
-    // TODO weird that you have to give a powerup a position, even if just using
-    // it to apply directly
     new Cone(2).apply(this);
-    this.maxHealth = 2;
-    this.gainHealth(2);
+    this.maxHealth = 18 * (matryoshka + 1);
+    this.gainHealth(this.maxHealth);
     this.bulletSpeed = 5;
     this.bulletLifetime = 300;
     this.fireDelay = 0;

--- a/static/game/shooter.js
+++ b/static/game/shooter.js
@@ -28,11 +28,7 @@ export class Shooter extends Enemy {
     matryoshka = 0
   ) {
     super(pos, vel, acc, matryoshka);
-    // TODO check this maxhealth
-    this.maxHealth = 2;
-    // TODO @Joe is it okay to do this before setting current health? I think
-    // this is only working because undefined is being coerced into a zero,
-    // which is pretty sketchy.
+    this.maxHealth = 20 * (matryoshka + 1);
     this.gainHealth(this.maxHealth);
     this.fireDelay = 90;
     this.bulletSpeed = 5;

--- a/static/game/statuseffects/burning.js
+++ b/static/game/statuseffects/burning.js
@@ -4,8 +4,8 @@ import { Particle, EffectEnum } from "../particle.js";
 import { Vector } from "../../modules/vector.js";
 import { addParticle } from "../../modules/gamemanager.js";
 
-const CHANCE_TO_BURN = 1 / 60; // chance to take damage each step
-const BURNING_DAMAGE = 5;
+const CHANCE_TO_BURN = 1 / 10; // chance to take damage each step
+const BURNING_DAMAGE = 3;
 
 export class Burning extends StatusEffect {
   /**

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,7 @@
+canvas:fullscreen {
+  cursor: none;
+}
+
 body,
 html {
   height: 100%;


### PR DESCRIPTION
Merge #71 first please.

Made some tweaks to various power ups to make them more fun/balanced

  - Littlify removed
  - RovingBombs -> SlipperyBombs
  - Yeet removed
  - Sniper -> Yeet
  - Left and Right added
  - Slippery bombs don't move if you aren't moving when you place them
  - Swapped downsides of Cone and Xplode: now Cone decreases your fire rate and Xplode decreases your damage
  - Changed health and damage values to be more consistent between hero and enemies
  - Flamethrower only has a chance to light enemies on fire instead of always doing it